### PR TITLE
chore(tsconfig): use bundler type for new inversify

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "target": "esnext",
     "module": "esnext",
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "lib": ["ES2017", "webworker", "dom"],
     "sourceMap": true,


### PR DESCRIPTION
inversify v8 is ESM only so we need to use 'bundler' type else we have an error

```
There are types at 'podman-desktop-ibmcloud-account-ext/node_modules/inversify/lib/index.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.
```