### PR TITLE
fix: resolve GHSA-mh99-v99m-4gvg in brace-expansion

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,9 @@ overrides:
   minimatch@<3.1.3: 3.1.5
   minimatch@>=9.0.0 <9.0.7: 9.0.9
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^2: 2.1.4
+  brace-expansion@^5: 5.0.9
   yaml@>=2.0.0 <2.8.3: ^2.8.3
   fast-uri@<=3.1.0: '>=3.1.1'
   fast-uri@>=4.0.0 <=4.1.0: '>=4.1.1'
@@ -1299,15 +1301,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@2.1.4:
     resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
-
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
-    engines: {node: 20 || >=22}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -4080,7 +4078,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.43: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -4088,10 +4086,6 @@ snapshots:
   brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.8:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.9:
     dependencies:
@@ -5199,7 +5193,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@10.2.6:
     dependencies:
@@ -5207,7 +5201,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,7 +6,9 @@ overrides:
   minimatch@<3.1.3: 3.1.5
   minimatch@>=9.0.0 <9.0.7: 9.0.9
   picomatch@>=4.0.0 <4.0.4: 4.0.4
-  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@^1: 1.1.18
+  brace-expansion@^2: 2.1.4
+  brace-expansion@^5: 5.0.9
   yaml@>=2.0.0 <2.8.3: ^2.8.3
   fast-uri@<=3.1.0: '>=3.1.1'
   fast-uri@>=4.0.0 <=4.1.0: '>=4.1.1'


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-mh99-v99m-4gvg in `brace-expansion`.

**Advisory**: brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash
**Vulnerable versions**: <1.1.17
**Patched versions**: >=1.1.17
**Advisory URL**: https://github.com/advisories/GHSA-mh99-v99m-4gvg

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-mh99-v99m-4gvg: _brace-expansion: DoS via unbounded expansion length causing an out-of-memory process crash_

### How to test this PR?

Run `pnpm audit` and verify GHSA-mh99-v99m-4gvg is no longer reported